### PR TITLE
removing package bundle job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,10 +280,7 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
-      - package_bundle:
-          requires:
-            - maven_n_git_release
-
+          
   standalone_nexus_staging:
     # ---
     # Running the nexus staging makes sense only when the


### PR DESCRIPTION
removing the package bundle job , there is no zip files t copy , find here the link to the CircleCI Pipeline : 

https://app.circleci.com/pipelines/github/gravitee-io/gravitee-resource-auth-provider/9/workflows/331277cf-80de-4d5d-93bb-d4024129c8d4/jobs/15